### PR TITLE
fix(manifest): use service_worker instead of background scripts

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,7 +26,7 @@
     }
   },
   "background": {
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
   "icons": {
     "16": "icons/icon16.png",


### PR DESCRIPTION
Update background configuration to use `service_worker` instead of `scripts` to comply with Chrome Extension Manifest V3.
